### PR TITLE
Implement basic WCAG checker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+bin/
+obj/
+*.pdf

--- a/AccessibilityChecker/AccessibilityChecker.csproj
+++ b/AccessibilityChecker/AccessibilityChecker.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="HtmlAgilityPack" Version="1.12.1" />
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
+    <PackageReference Include="QuestPDF" Version="2025.5.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
+  </ItemGroup>
+
+</Project>

--- a/AccessibilityChecker/AccessibilityChecker.http
+++ b/AccessibilityChecker/AccessibilityChecker.http
@@ -1,0 +1,6 @@
+@AccessibilityChecker_HostAddress = http://localhost:5266
+
+GET {{AccessibilityChecker_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/AccessibilityChecker/Program.cs
+++ b/AccessibilityChecker/Program.cs
@@ -1,0 +1,56 @@
+using AccessibilityChecker.Services;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+builder.Services.AddSingleton<AccessibilityAnalyzer>();
+builder.Services.AddSingleton<AccessibilityDeclarationGenerator>();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+
+app.MapPost("/api/accessibility/analyze", async (string url, AccessibilityAnalyzer analyzer) =>
+{
+    if (string.IsNullOrWhiteSpace(url))
+    {
+        return Results.BadRequest("URL missing");
+    }
+    try
+    {
+        var result = await analyzer.AnalyzeAsync(url);
+        return Results.Ok(result);
+    }
+    catch (HttpRequestException ex)
+    {
+        return Results.BadRequest($"Error fetching URL: {ex.Message}");
+    }
+});
+
+app.MapPost("/api/accessibility/declaration", async (string url, AccessibilityAnalyzer analyzer, AccessibilityDeclarationGenerator generator) =>
+{
+    if (string.IsNullOrWhiteSpace(url))
+    {
+        return Results.BadRequest("URL missing");
+    }
+    try
+    {
+        var result = await analyzer.AnalyzeAsync(url);
+        var pdfBytes = generator.Generate(url, result);
+        return Results.File(pdfBytes, "application/pdf", "DichiarazioneAccessibilita.pdf");
+    }
+    catch (HttpRequestException ex)
+    {
+        return Results.BadRequest($"Error fetching URL: {ex.Message}");
+    }
+});
+
+app.Run();

--- a/AccessibilityChecker/Properties/launchSettings.json
+++ b/AccessibilityChecker/Properties/launchSettings.json
@@ -1,0 +1,41 @@
+﻿{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:6006",
+      "sslPort": 44374
+    }
+  },
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "http://localhost:5266",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "applicationUrl": "https://localhost:7177;http://localhost:5266",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/AccessibilityChecker/Services/AccessibilityAnalyzer.cs
+++ b/AccessibilityChecker/Services/AccessibilityAnalyzer.cs
@@ -1,0 +1,49 @@
+using HtmlAgilityPack;
+using System.Net.Http;
+using System.Threading.Tasks;
+using System.Linq;
+
+namespace AccessibilityChecker.Services
+{
+    public record AccessibilityResult(
+        bool HasTitle,
+        bool HasLang,
+        int ImagesWithoutAlt,
+        int InputsWithoutLabel
+    );
+
+    public class AccessibilityAnalyzer
+    {
+        private readonly HttpClient _httpClient = new HttpClient();
+
+        public async Task<AccessibilityResult> AnalyzeAsync(string url)
+        {
+            var html = await _httpClient.GetStringAsync(url);
+            var doc = new HtmlDocument();
+            doc.LoadHtml(html);
+
+            bool hasTitle = doc.DocumentNode.SelectSingleNode("//title") != null;
+            bool hasLang = doc.DocumentNode.SelectSingleNode("//html[@lang]") != null;
+
+            int imagesWithoutAlt = doc.DocumentNode
+                .SelectNodes("//img")?
+                .Count(img => img.GetAttributeValue("alt", string.Empty).Trim() == string.Empty) ?? 0;
+
+            int inputsWithoutLabel = doc.DocumentNode
+                .SelectNodes("//input[not(@type='hidden')]")?
+                .Count(input => {
+                    var id = input.GetAttributeValue("id", string.Empty);
+                    if (!string.IsNullOrEmpty(id))
+                    {
+                        var label = doc.DocumentNode.SelectSingleNode($"//label[@for='{id}']");
+                        if (label != null) return false;
+                    }
+                    // check ancestor label
+                    if (input.Ancestors("label").Any()) return false;
+                    return true;
+                }) ?? 0;
+
+            return new AccessibilityResult(hasTitle, hasLang, imagesWithoutAlt, inputsWithoutLabel);
+        }
+    }
+}

--- a/AccessibilityChecker/Services/AccessibilityDeclarationGenerator.cs
+++ b/AccessibilityChecker/Services/AccessibilityDeclarationGenerator.cs
@@ -1,0 +1,35 @@
+using QuestPDF.Fluent;
+using QuestPDF.Helpers;
+using QuestPDF.Infrastructure;
+using System.IO;
+
+namespace AccessibilityChecker.Services
+{
+    public class AccessibilityDeclarationGenerator
+    {
+        public byte[] Generate(string url, AccessibilityResult result)
+        {
+            var document = Document.Create(container =>
+            {
+                container.Page(page =>
+                {
+                    page.Size(PageSizes.A4);
+                    page.Margin(2, Unit.Centimetre);
+                    page.Content().Column(col =>
+                    {
+                        col.Item().Text("Dichiarazione di Accessibilità").FontSize(20).Bold();
+                        col.Item().Text($"URL analizzata: {url}");
+                        col.Item().Text($"Titolo presente: {result.HasTitle}");
+                        col.Item().Text($"Attributo lang presente: {result.HasLang}");
+                        col.Item().Text($"Immagini senza alt: {result.ImagesWithoutAlt}");
+                        col.Item().Text($"Campi input senza label: {result.InputsWithoutLabel}");
+                    });
+                });
+            });
+
+            using var stream = new MemoryStream();
+            document.GeneratePdf(stream);
+            return stream.ToArray();
+        }
+    }
+}

--- a/AccessibilityChecker/appsettings.Development.json
+++ b/AccessibilityChecker/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/AccessibilityChecker/appsettings.json
+++ b/AccessibilityChecker/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/Readme.txt
+++ b/Readme.txt
@@ -1,1 +1,16 @@
-Test codex
+# Accessibility Checker
+
+Questo progetto contiene un semplice servizio Web in .NET 8 che consente di analizzare una URL e verificare alcuni requisiti di accessibilità (WCAG 2.2). 
+
+## Come eseguire
+
+1. Installare .NET 8.
+2. Spostarsi nella cartella `AccessibilityChecker` ed eseguire:
+   ```bash
+   dotnet run
+   ```
+3. Utilizzare gli endpoint HTTP:
+   - `POST /api/accessibility/analyze` con parametro `url` nel body per ottenere un report JSON.
+   - `POST /api/accessibility/declaration` con parametro `url` nel body per ricevere un PDF chiamato "DichiarazioneAccessibilita.pdf".
+
+Gli esempi di controllo comprendono titolo della pagina, attributo `lang`, immagini senza `alt` e campi input senza label.


### PR DESCRIPTION
## Summary
- add an ASP.NET 8 minimal API to check some WCAG criteria for a URL
- generate a PDF "Dichiarazione di Accessibilita" with QuestPDF
- document how to run the service in `Readme.txt`

## Testing
- `dotnet build`

------
https://chatgpt.com/codex/tasks/task_e_6848644507148327b4af19cdffa520b6